### PR TITLE
Suggestion for clean build detection fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TL_CONFIG_PATH="${SRCROOT}/${TL_PROJ_ROOT_FOLDER}/Resources/NStack/NStack.plist"
 TL_OUT_PATH="${SRCROOT}/${TL_PROJ_ROOT_FOLDER}/Classes/Language"
 
 # Check if doing a clean build
-if test -d "${DERIVED_FILE_DIR}"; then
+if test -f "${DERIVED_FILE_DIR}/*.h"; then
 echo "Not clean build, won't fetch translations this time."
 else
 echo "Clean build. Getting translations..."


### PR DESCRIPTION
The reason the old method doesn't work anymore is that the directory already exists because the entitlements file is put in there before this script is run. However, a project specific .h file is only put there afterwards which provides a way for us to check whether we're in a clean build.