### PR TITLE
Use a lock file in generator build phase script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ TL_CONFIG_PATH="${SRCROOT}/${TL_PROJ_ROOT_FOLDER}/Resources/NStack/NStack.plist"
 TL_OUT_PATH="${SRCROOT}/${TL_PROJ_ROOT_FOLDER}/Classes/Language"
 
 # Check if doing a clean build
-if test -f "${DERIVED_FILE_DIR}/*.h"; then
+if test -f "${DERIVED_FILE_DIR}/TranslationsGenerator.lock"; then
 echo "Not clean build, won't fetch translations this time."
 else
 echo "Clean build. Getting translations..."
-"${TL_GEN_PATH}/Contents/MacOS/nstack-translations-generator" -plist "${TL_CONFIG_PATH}" -output "${TL_OUT_PATH}"
+"${TL_GEN_PATH}/Contents/MacOS/nstack-translations-generator" -plist "${TL_CONFIG_PATH}" -output "${TL_OUT_PATH}" -standalone
+touch "${DERIVED_FILE_DIR}/TranslationsGenerator.lock" # create lock file
 fi
 ~~~
 


### PR DESCRIPTION
I've tested the change made in #16 and it seems that it did not help in my project, so instead I came up with a more stable way of making sure translations get generated only on clean builds.